### PR TITLE
feat(logging): Switch to JSON logs and add Sentry context

### DIFF
--- a/handlers/goal_setting.py
+++ b/handlers/goal_setting.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import sentry_sdk
 from datetime import timedelta, datetime
 from typing import Final, cast, Any, Dict
 
@@ -73,11 +74,15 @@ def build_setgoal_conv(goal_manager: GoalManager) -> ConversationHandler:
 
     async def start(update: Update, context: ContextTypes.DEFAULT_TYPE):
         USER_COMMANDS_TOTAL.labels(command_name="/setgoal").inc()
+        if update.effective_user:
+            sentry_sdk.set_tag("user_id", update.effective_user.id)
         assert update.message is not None
         await update.message.reply_text(PROMPT_GOAL_TEXT)
         return TEXT_GOAL
 
     async def input_goal(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if update.effective_user:
+            sentry_sdk.set_tag("user_id", update.effective_user.id)
         assert update.message is not None
         text_raw = update.message.text or ""
         text = text_raw.strip()
@@ -90,6 +95,8 @@ def build_setgoal_conv(goal_manager: GoalManager) -> ConversationHandler:
         return DEADLINE
 
     async def input_deadline(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if update.effective_user:
+            sentry_sdk.set_tag("user_id", update.effective_user.id)
         assert update.message is not None
         text_raw = update.message.text or ""
         text = text_raw.strip()
@@ -108,6 +115,10 @@ def build_setgoal_conv(goal_manager: GoalManager) -> ConversationHandler:
         return AVAILABLE_TIME
 
     async def input_available_time(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        assert update.effective_user is not None
+        user_id = update.effective_user.id
+        sentry_sdk.set_tag("user_id", user_id)
+
         assert update.message is not None
         text_raw = update.message.text or ""
         text = text_raw.strip()
@@ -139,6 +150,8 @@ def build_setgoal_conv(goal_manager: GoalManager) -> ConversationHandler:
         return ConversationHandler.END
 
     async def cancel(update: Update, context: ContextTypes.DEFAULT_TYPE):
+        if update.effective_user:
+            sentry_sdk.set_tag("user_id", update.effective_user.id)
         assert update.message is not None
         await update.message.reply_text(CONVERSATION_CANCELLED_TEXT)
         return ConversationHandler.END

--- a/handlers/task_management.py
+++ b/handlers/task_management.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sentry_sdk
 from datetime import datetime
 
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
@@ -54,6 +55,7 @@ def build_task_handlers(goal_manager: GoalManager):
         """Handles the /today command, displaying the current day's task."""
         USER_COMMANDS_TOTAL.labels(command_name="/today").inc()
         assert update.effective_user is not None
+        sentry_sdk.set_tag("user_id", update.effective_user.id)
         assert update.message is not None
         task = await goal_manager.get_today_task(update.effective_user.id)
         if task:
@@ -71,6 +73,7 @@ def build_task_handlers(goal_manager: GoalManager):
         """Handles the /status command, displaying goal progress and upcoming tasks."""
         USER_COMMANDS_TOTAL.labels(command_name="/status").inc()
         assert update.effective_user is not None
+        sentry_sdk.set_tag("user_id", update.effective_user.id)
         assert update.message is not None
         data = await goal_manager.get_detailed_status(update.effective_user.id)
 
@@ -117,6 +120,7 @@ def build_task_handlers(goal_manager: GoalManager):
         """Entry point for the /check conversation; displays today's task and status buttons."""
         USER_COMMANDS_TOTAL.labels(command_name="/check").inc()
         assert update.effective_user is not None
+        sentry_sdk.set_tag("user_id", update.effective_user.id)
         assert update.message is not None
         task = await goal_manager.get_today_task(update.effective_user.id)
         if not task:
@@ -158,8 +162,9 @@ def build_task_handlers(goal_manager: GoalManager):
         await query.answer()
         status_val = str(query.data)
         assert update.effective_user is not None
+        sentry_sdk.set_tag("user_id", query.from_user.id)
         await goal_manager.batch_update_task_statuses(
-            update.effective_user.id,
+            query.from_user.id,
             {format_date(datetime.now()): status_val},
         )
         await query.edit_message_text(CHECK_STATUS_UPDATED_TEXT)
@@ -171,6 +176,7 @@ def build_task_handlers(goal_manager: GoalManager):
         """Handles the /motivation command, sending a motivational message."""
         USER_COMMANDS_TOTAL.labels(command_name="/motivation").inc()
         assert update.effective_user is not None
+        sentry_sdk.set_tag("user_id", update.effective_user.id)
         assert update.message is not None
         msg = await goal_manager.generate_motivation_message(update.effective_user.id)
         await update.message.reply_text(msg)

--- a/scheduler/tasks.py
+++ b/scheduler/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sentry_sdk
 from datetime import datetime, time as dt_time, timezone
 import asyncio
 from typing import TYPE_CHECKING, cast, Dict, Any
@@ -105,6 +106,8 @@ class Scheduler:
 
     async def _send_today_task(self, bot: Bot, user_id: int):
         """(Job) Sends the daily task to the user if it's not completed."""
+        sentry_sdk.set_tag("user_id", user_id)
+        sentry_sdk.set_tag("job_name", "_send_today_task")
         try:
             task = await self.goal_manager.get_today_task(user_id)
             if task:
@@ -124,6 +127,8 @@ class Scheduler:
 
     async def _send_evening_reminder(self, bot: Bot, user_id: int):
         """(Job) Sends an evening reminder to check off the daily task."""
+        sentry_sdk.set_tag("user_id", user_id)
+        sentry_sdk.set_tag("job_name", "_send_evening_reminder")
         try:
             await bot.send_message(
                 chat_id=user_id,
@@ -136,6 +141,8 @@ class Scheduler:
 
     async def _send_motivation(self, bot: Bot, user_id: int):
         """(Job) Sends a motivational message to the user."""
+        sentry_sdk.set_tag("user_id", user_id)
+        sentry_sdk.set_tag("job_name", "_send_motivation")
         try:
             msg = await self.goal_manager.generate_motivation_message(user_id)
             await bot.send_message(chat_id=user_id, text=msg)

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -34,7 +34,6 @@ def setup_logging(log_level: str | int = "INFO") -> structlog.BoundLogger:
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,  # Prepare for stdlib formatter
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
-        formatter_class=structlog.stdlib.ProcessorFormatter,  # Use this for JSON output via stdlib
         processor=structlog.processors.JSONRenderer(),  # The actual JSON rendering
         wrapper_class=structlog.make_filtering_bound_logger(
             logging.getLevelName(log_level) if isinstance(log_level, str) else log_level

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -6,7 +6,7 @@ import structlog
 
 
 def setup_logging(log_level: str | int = "INFO") -> structlog.BoundLogger:
-    """Sets up standard logging and structlog.
+    """Sets up standard logging and structlog with JSON output.
 
     Args:
         log_level: The logging level (str or int).
@@ -15,22 +15,30 @@ def setup_logging(log_level: str | int = "INFO") -> structlog.BoundLogger:
         BoundLogger: The root structlog logger to which context can be bound.
     """
     # Basic configuration for stdlib logging (for third-party libraries)
+    # This will now primarily handle the JSON output from structlog.
     logging.basicConfig(
-        level=log_level, format="%(asctime)s %(levelname)-8s %(name)s: %(message)s"
+        level=log_level, format="%(message)s"  # Format to output structlog's JSON as is
     )
 
     # Configure structlog
+    shared_processors = [
+        structlog.contextvars.merge_contextvars,  # Handles context in async code
+        structlog.stdlib.add_logger_name,  # Adds logger name, like stdlib
+        structlog.stdlib.add_log_level,  # Adds log level
+        structlog.processors.TimeStamper(fmt="iso"),
+    ]
+
     structlog.configure(
-        processors=[
-            structlog.contextvars.merge_contextvars,  # Handles context in async code
-            structlog.processors.add_log_level,
-            structlog.processors.TimeStamper(fmt="iso"),
-            structlog.dev.ConsoleRenderer(),  # For development; consider JSONRenderer for prod
+        processors=shared_processors
+        + [
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,  # Prepare for stdlib formatter
         ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        formatter_class=structlog.stdlib.ProcessorFormatter,  # Use this for JSON output via stdlib
+        processor=structlog.processors.JSONRenderer(),  # The actual JSON rendering
         wrapper_class=structlog.make_filtering_bound_logger(
             logging.getLevelName(log_level) if isinstance(log_level, str) else log_level
         ),
-        logger_factory=structlog.stdlib.LoggerFactory(),
         cache_logger_on_first_use=True,
     )
 

--- a/utils/logging.py
+++ b/utils/logging.py
@@ -31,10 +31,10 @@ def setup_logging(log_level: str | int = "INFO") -> structlog.BoundLogger:
     structlog.configure(
         processors=shared_processors
         + [
+            structlog.processors.JSONRenderer(),
             structlog.stdlib.ProcessorFormatter.wrap_for_formatter,  # Prepare for stdlib formatter
         ],
         logger_factory=structlog.stdlib.LoggerFactory(),
-        processor=structlog.processors.JSONRenderer(),  # The actual JSON rendering
         wrapper_class=structlog.make_filtering_bound_logger(
             logging.getLevelName(log_level) if isinstance(log_level, str) else log_level
         ),


### PR DESCRIPTION
This PR implements the first part of task #17 (Расширенное логирование и алерты Sentry):

- Configured `structlog` to output logs in JSON format.
- Added `user_id` to Sentry context in all relevant Telegram command handlers.
- Added `user_id` and `job_name` to Sentry context in scheduled tasks.

This will improve log parsing and error tracking in Sentry.
Next steps for #17 would be to ensure `goal_id` is added (once available) and configure Sentry alerts.