### PR TITLE
Feat: Update release practices and Docker CI for tags

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,37 +1,47 @@
-name: Docker Image CI
+name: Docker Image CI and Release
 
 on:
   push:
     branches: [ main ]
+    tags:
+      - 'v*.*.*' # Trigger on tags like v1.0.0
+      - 'v*.*'   # Trigger on tags like v0.1
   workflow_dispatch:
 
 jobs:
-  build-and-push:
-    if: ${{ github.repository == 'bivlked/target-assistant-bot' && github.ref == 'refs/heads/main' }}
+  build-and-push-release:
+    # Run this job only for tags in the main repository
+    if: ${{ github.repository == 'bivlked/target-assistant-bot' && startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+      packages: write # Required to push to GHCR
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-      - name: Log in to GHCR
+      - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker
+      - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository }}
-
-      - name: Build and push Docker image
+          images: ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}
+          tags: |
+            type=semver,pattern={{version}} # Extracts version from tag (e.g., v1.0.0 -> 1.0.0)
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest # Always tag the release build as latest as well
+            
+      - name: Build and push Docker image to GHCR
+        id: build-and-push
         uses: docker/build-push-action@v5
         with:
           context: .
-          push: true
+          push: true # Push the image as this is a release
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }} 

--- a/deploy/update-bot.sh
+++ b/deploy/update-bot.sh
@@ -1,17 +1,60 @@
 #!/usr/bin/env bash
-# Обновляет репозиторий и перезапускает systemd-сервис бота
+# Fetches the latest tag, checks it out, and restarts the bot's systemd service.
+# Falls back to pulling the main branch if no tags are found.
 set -euo pipefail
 
-REPO_DIR="/root/target-assistant-bot"
+REPO_DIR="/root/target-assistant-bot" # Ensure this path is correct on your server
 SERVICE_NAME="targetbot.service"
+LOG_PREFIX="[update-bot]"
 
-cd "$REPO_DIR"
+cd "$REPO_DIR" || { echo "$LOG_PREFIX Failed to cd into $REPO_DIR" >&2; exit 1; }
 
-# Получаем последние изменения
-if git pull --ff-only; then
-    echo "[update-bot] Репозиторий обновлён. Перезапуск службы $SERVICE_NAME"
-    sudo systemctl restart "$SERVICE_NAME"
+echo "$LOG_PREFIX Fetching latest tags from origin..."
+if ! git fetch --tags origin; then
+    echo "$LOG_PREFIX git fetch --tags origin failed" >&2
+    exit 1
+fi
+
+# Get the latest tag. If no tags, this will be empty.
+LATEST_TAG=$(git describe --tags $(git rev-list --tags --max-count=1) 2>/dev/null || true)
+
+if [ -z "$LATEST_TAG" ]; then
+    echo "$LOG_PREFIX No tags found. Falling back to the main branch."
+    # Fallback to main if no tags exist (e.g., initial setup)
+    # Ensure we are on main and it's up to date
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+    if [ "$CURRENT_BRANCH" != "main" ]; then
+        echo "$LOG_PREFIX Not on main branch. Checking out main..."
+        if ! git checkout main; then
+            echo "$LOG_PREFIX git checkout main failed" >&2
+            exit 1
+        fi
+    fi
+    echo "$LOG_PREFIX Pulling latest changes from origin/main..."
+    if ! git pull origin main --ff-only; then
+        echo "$LOG_PREFIX git pull origin main failed" >&2
+        exit 1
+    fi
+    echo "$LOG_PREFIX Updated to the latest version of the main branch. Restarting service $SERVICE_NAME..."
+elif git describe --exact-match --tags HEAD 2>/dev/null | grep -q "$LATEST_TAG"; then
+    echo "$LOG_PREFIX Already on the latest tag: $LATEST_TAG. No update needed."
+    # Optional: restart service even if on latest tag, if configuration might have changed
+    # echo "$LOG_PREFIX Restarting service $SERVICE_NAME anyway..."
+    # sudo systemctl restart "$SERVICE_NAME"
+    # echo "$LOG_PREFIX Service $SERVICE_NAME restarted."
+    exit 0 # Exit successfully, no actual update performed but we are on the latest tag
 else
-    echo "[update-bot] git pull завершился с ошибкой" >&2
+    echo "$LOG_PREFIX Latest tag found: $LATEST_TAG. Checking out..."
+    if ! git checkout "$LATEST_TAG"; then
+        echo "$LOG_PREFIX git checkout to tag $LATEST_TAG failed" >&2
+        exit 1
+    fi
+    echo "$LOG_PREFIX Repository updated to tag $LATEST_TAG. Restarting service $SERVICE_NAME..."
+fi
+
+if sudo systemctl restart "$SERVICE_NAME"; then
+    echo "$LOG_PREFIX Service $SERVICE_NAME restarted successfully."
+else
+    echo "$LOG_PREFIX Failed to restart service $SERVICE_NAME." >&2
     exit 1
 fi 


### PR DESCRIPTION
Implements initial parts of Task #2 (Release Practices) and Task #18 (Docker CI Publish on Release):

- Updated `deploy/update-bot.sh` to fetch and checkout the latest Git tag. Includes a fallback to the `main` branch if no tags are found.
- Updated `.github/workflows/docker.yml` to trigger on new tags (e.g., `v*.*.*`, `v*.*`) and publish Docker images to GHCR, tagged symptômes and with `latest`.